### PR TITLE
chore: Update CodeQL Action v2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -52,7 +52,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v2
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -66,4 +66,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Updating CodeQA Action to V2 since V1 is being deprecated.

Refs: https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/

# Closes: #[ticket no]

## Type of changes?

- [ ] Bug fixes: Non-breaking change which fixes an issue
- [ ] New feature: Non-breaking change which adds a new feature
- [ ] Performance improvement: Non-breaking change which improves performance
- [ ] Documentation: Non-breaking change which improves documentation
- [x] Other: Non-breaking change which does not fit into the above categories
- [ ] Breaking change: A breaking change which requires a new version of the library

## Checklist for Java project

- [x] Change not related to Java project

> Following checklists are optional if above checkbox is selected:
>
> - [ ] Copyright banner comment added to newly added files, except `*.md`, `*.yml`, `*.json`?
> - [ ] Proper JavaDoc updated in main and test classes for all public classes and methods?
> - [ ] Tests added for changes?
> - [ ] Tests are passing locally?
> - [ ] Check style checks are passing locally?
> - [ ] Test coverage is at least 80% for newly added changes?
> - [ ] There are no SonarCloud issues?
> - [ ] README updated? (if applicable)
> - [ ] Documentation website updated for the PR raised?

## Checklist for Website

- [x] Change not related to Website project

> Following is optional if above checkbox is selected:
>
> - [ ] Lint check passes locally?
> - [ ] Prettier check passes locally?
> - [ ] Build command working fine locally?

## Reviewers

### @WasiqBhamla/boyka-core

> IMPORTANT: Make sure to check the `Allow edits from maintainers` box below this window


<a href="https://gitpod.io/#https://github.com/WasiqBhamla/boyka-framework/pull/75"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

